### PR TITLE
Change appName to appId since appName no longer works

### DIFF
--- a/examples/Trading-GetOrders.js
+++ b/examples/Trading-GetOrders.js
@@ -11,7 +11,7 @@ ebay.xmlRequest({
   // app/environment
   devId: '...........',
   certId: '...........',
-  appName: '...........',
+  appId: '...........',
   sandbox: true,
 
   // per user


### PR DESCRIPTION
I used this example only to find out a few hours later the example code is outdated