### PR TITLE
Fixed "has stacks" error tests failing on macOS 10.12.1 and node v7.0.0.

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -10,9 +10,9 @@ var
 
 function EbayClientError(message, extraProps) {
   Error.apply(this, arguments);
-  Error.captureStackTrace(this, this.constructor);
   this.name = this.constructor.name;
   this.message = message;
+  Error.captureStackTrace(this, this.constructor);
   _.defaults(this, extraProps);
 }
 inherits(EbayClientError, Error);


### PR DESCRIPTION
All tests “has stack“ in errors.test.js failed on my mac running macOS
10.12.1 and node v7.0.0.

Moving the call `Error.captureStackTrace(this, this.constructor)` after
the name and message have been set solved the issue.

I spent a lot of time trying to understand why this is happening, but I couldn't find a proper answer. In fact, all tests do pass on travis-ci running node 4.1, 4.2, 0.12, 0.10.