### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ This module uses the [debug](https://github.com/visionmedia/debug) module for in
 
 Run your app (or node REPL) with `DEBUG=ebay* ...` to see output. 
 
+You can test out this API at [RapidAPI](https://rapidapi.com/package/eBay/functions?utm_source=GitHubEbay&utm_medium=button)
+
 
 Enjoy!
 


### PR DESCRIPTION
I've added a link to Ebay's API functions page. This will give devs an option to test out Ebay's API before usage.